### PR TITLE
FIX: Product Thumbnail Popup

### DIFF
--- a/htdocs/theme/eldy/style.css.php
+++ b/htdocs/theme/eldy/style.css.php
@@ -4758,5 +4758,13 @@ div.tabsElem a.tab {
     }
 }
 
+.ui-dialog-content.ui-widget-content > object {
+    max-height: 100%;
+    width: auto;
+    margin-left: auto;
+    margin-right: auto;
+    display: block;
+}
+
 <?php
 if (is_object($db)) $db->close();


### PR DESCRIPTION
# Fix
When clicking on the product thumbnail (via product card), the popup picture never scaled to the popup size. 