### PR TITLE
FIX: Product Status Incorrect on Stock Alert Box

### DIFF
--- a/htdocs/core/boxes/box_produits_alerte_stock.php
+++ b/htdocs/core/boxes/box_produits_alerte_stock.php
@@ -199,7 +199,7 @@ class box_produits_alerte_stock extends ModeleBoxes
 
                     $this->info_box_contents[$line][] = array(
                         'td' => 'align="right" width="18" class="classfortooltip"',
-                        'text' => '<span class="statusrefbuy">'.$productstatic->LibStatut($objp->tobuy,3,0).'<span>',
+                        'text' => '<span class="statusrefbuy">'.$productstatic->LibStatut($objp->tobuy,3,1).'<span>',
                         'asis' => 1
                     );
 


### PR DESCRIPTION
- Products showing as `Not for sale` in the widget box were showing as 'for sale'
- This commit fixes the typo here ( https://github.com/Dolibarr/dolibarr/commit/8f7371cdf0f6b7e8a286a783673f847daeac6706#diff-cf2fe589a3fef23e824b9d4e8712e0ac )
